### PR TITLE
box_select Bokeh tool should not be present in the RangeXY example

### DIFF
--- a/linked_plots/callback_test.ipynb
+++ b/linked_plots/callback_test.ipynb
@@ -355,7 +355,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Because of the limitations mentioned bove in the butler implementation, we'll have to look at the data output repository to get the list of the patches available. \n",
+    "Because of the limitations mentioned above in the butler implementation, we'll have to look at the data output repository to get the list of the patches available. \n",
     "\n",
     "Then we can loop over the dataIds and load the corresponding catalogs."
    ]
@@ -402,7 +402,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As mentioned above we need datashader to visualize a dataset of this size. See how nice it plays with Bokeh pan and zomm tools."
+    "As mentioned above we need datashader to visualize a dataset of this size. See how nice it plays with Bokeh pan and zoom tools."
    ]
   },
   {
@@ -536,7 +536,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, we can use another linked stream called `RangeXY` which gives us the `x_range`,  `y_range` of the current dispay. This way we can use the `Pan` and `Zoom` tools to nagivate through the RA, Dec plot and see the histogram update.\n"
+    "Alternatively, we can use another linked stream called `RangeXY` which gives us the `x_range`,  `y_range` of the current dispay. This way we can use the `Pan` and `Zoom` tools to nagivate through the RA, Dec plot and see the histogram update.\n",
+    "\n",
+    "We first create a new instance of the datashader object that will be used as the source of \"selection\" for the `RangeXY` example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = datashade(hv.Points(ds))\n",
+    "image"
    ]
   },
   {


### PR DESCRIPTION
This is an attempt to fix the issue described in PR https://github.com/lsst-com/notebooks/pull/28

Create a new instance of the datashader object that will be the
source of selection for the RangeXY example, this way the box_select
tool is not shown, as expect.